### PR TITLE
Set DateTimeFormatter pattern to null by default

### DIFF
--- a/src/Extension/Core/Type/DateTimeType.php
+++ b/src/Extension/Core/Type/DateTimeType.php
@@ -24,7 +24,7 @@ class DateTimeType extends BaseElementType
             'locale'      => \Locale::getDefault(),
             'date_format' => \IntlDateFormatter::MEDIUM,
             'time_format' => \IntlDateFormatter::MEDIUM,
-            'pattern'     => '',
+            'pattern'     => null,
         ]);
     }
 


### PR DESCRIPTION
DateTimeFormatter returns an empty string when `''` set as a pattern.