### PR TITLE
Implode CollectionType value in twig template

### DIFF
--- a/src/Extension/Core/Type/CollectionType.php
+++ b/src/Extension/Core/Type/CollectionType.php
@@ -105,6 +105,6 @@ class CollectionType extends BaseElementType
             }
         }
 
-        $view->vars['value'] = implode($view->vars['item_separator'], $collection);
+        $view->vars['value'] = $collection;
     }
 }

--- a/src/Resources/views/Grid/grid.html.twig
+++ b/src/Resources/views/Grid/grid.html.twig
@@ -98,3 +98,11 @@
         {%- endfor -%}
     {% endif %}
 {%- endblock -%}
+
+{%- block grid_collection_widget -%}
+    {% if value is iterable %}
+        {{ value|join(item_separator) }}
+    {% else %}
+        {{ value }}
+    {% endif %}
+{%- endblock -%}


### PR DESCRIPTION
To allow more flexibility in custom GridTypes for CollectionType elements it would be useful to pass the collection values as an array to twig and implode the data directly in the twig template.